### PR TITLE
讓 tooltip 中同一個詞類有超過一個定義時, 列表的數字不會被蓋住

### DIFF
--- a/styles.scss
+++ b/styles.scss
@@ -685,6 +685,9 @@ span {
         }
         margin: 0;
         padding: 0;
+		&:not(:only-child) {
+			margin-left: 20px;
+		}
     }
     .ol, .definition {
         margin: 0;


### PR DESCRIPTION
在 tooltip 裡的 style 會讓 "名", "動", 蓋住 `<ol>` 產生的數字
當類別內只有一個定義時看起來 ok, 會像是 (from #劉): 

```
    *形*  枝葉稀疏、零落。
```

但超過一個定義時第一個定義的 "1" 會被蓋住於是變成:

```
    *名* 斧、鉞一類的兵器。
      2.  姓。如明代有劉基。
```

附的 commit  會讓第二種狀況的 `<li>` 右移一些, 變成

```
    *名*  1. 斧、鉞一類的兵器。
          2.  姓。如明代有劉基。
```
