### PR TITLE
程式(不正常地)試圖繪製非中文筆順

### DIFF
--- a/main.js
+++ b/main.js
@@ -374,7 +374,7 @@
             return window.scrollTo(0, 0);
           });
         }
-        return strokeWords($('h1:first').text());
+        return strokeWords(replace$.call($('h1:first').text(), /[（(].*/, ''));
       });
       if (!('onhashchange' in window)) {
         $('body').on('click', 'a', function(){

--- a/main.ls
+++ b/main.ls
@@ -215,7 +215,7 @@ window.do-load = ->
 
     $ \body .on \click \.iconic-circle.stroke ->
       return ($('#strokes').fadeOut \fast -> $('#strokes').html(''); window.scroll-to 0 0) if $('svg, canvas').length
-      strokeWords $('h1:first').text!
+      strokeWords($('h1:first').text! - /[（(].*/) # Strip the english part and draw the strokes
 
     unless ``('onhashchange' in window)``
       $ \body .on \click \a ->


### PR DESCRIPTION
如: https://www.moedict.tw/#凱撒
其Title為: 凱撒(Cains Julius Caesar)
會為英文及半形字元配置canvas，但因沒有stroke資料畫不出來
另外會拖慢browser速度，在mobile device上明顯

先學`window.do-lookup`用regular expression把空白或括號後的東西去掉
