### PR TITLE
Fix submenu for small width (#62)

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,7 +38,7 @@
                           <a role="menuitem" class="lang-option a" href="#萌">國語辭典</a>
                         </li>
                         <li class="dropdown-submenu">
-                            <a class="icon-long-arrow-right">分類索引</a>
+                            <a class="icon-long-arrow-right" href="#">分類索引</a>
                             <ul class="dropdown-menu"><li role="presentation">
                                 <a class="lang-option a a-idiom" href="#，">諺語</a></li>
                             </li></ul>
@@ -47,7 +47,7 @@
                           <a role="menuitem" class="lang-option t" href="#!">臺灣閩南語</a>
                         </li>
                         <li class="dropdown-submenu">
-                            <a class="icon-long-arrow-right">分類索引</a>
+                            <a class="icon-long-arrow-right" href="#">分類索引</a>
                             <ul class="dropdown-menu"><li role="presentation">
                                 <a class="lang-option t t-idiom" href="#!。">諺語</a></li>
                             </li></ul>
@@ -56,7 +56,7 @@
                           <a role="menuitem" class="lang-option h" href="#:">臺灣客家語</a>
                         </li>
                         <li class="dropdown-submenu">
-                            <a class="icon-long-arrow-right">分類索引</a>
+                            <a class="icon-long-arrow-right" href="#">分類索引</a>
                             <ul class="dropdown-menu"><li role="presentation">
                                 <a class="lang-option h h-idiom icon-long-arrow-right" href="#:，">諺語</a></li>
                             </li></ul>

--- a/sass/styles.scss
+++ b/sass/styles.scss
@@ -1075,8 +1075,8 @@ canvas {
 }
 
 .dropdown-submenu {
-  position: relative;
-  > a:after {
+  > a { position: relative; }
+  > a:before {
     font-size: 10px;
     content: "▶";
     display: block;
@@ -1093,4 +1093,8 @@ canvas {
       top: 0;
     }
   }
+}
+
+@media only screen and (max-width: 767px) {
+    .dropdown-submenu > a:before { content: "▼"; }
 }

--- a/styles.css
+++ b/styles.css
@@ -10452,10 +10452,10 @@ canvas {
     display: none;
   }
 }
-.dropdown-submenu {
+.dropdown-submenu > a {
   position: relative;
 }
-.dropdown-submenu > a:after {
+.dropdown-submenu > a:before {
   font-size: 10px;
   content: "▶";
   display: block;
@@ -10469,4 +10469,10 @@ canvas {
   display: block;
   left: 100%;
   top: 0;
+}
+
+@media only screen and (max-width: 767px) {
+  .dropdown-submenu > a:before {
+    content: "▼" !important;
+  }
 }


### PR DESCRIPTION
Issues: 
1. In desktop, the hovering drops the right-pointing triangles to the middle (should be top);
2. Touch-only devices cannot toggle the expansion of sub-menu items at all:

Both are fixed. 2 was cause by `<a>` not having href attribute.

As for the bootstrap suggestion, I don't see one easily enough to implement. I'd tend to think if there is, it would be included in the official docs. As I previously mentioned, it [has been discussed in bootstrap](https://github.com/twbs/bootstrap/pull/6342) about the reason for dropping support of submenus, and also a suggested method(which is pretty much what we have here.)

So.. still...
![cooool](https://f.cloud.github.com/assets/1153134/1012524/83c87f14-0b71-11e3-8202-d569d3cf671c.png)
