### PR TITLE
Don't generate audio-id for single character without exact pronunciation auido

### DIFF
--- a/autolink.ls
+++ b/autolink.ls
@@ -107,7 +107,7 @@ for {t:title, h:heteronyms}:entry in entries
     b = b.replace(/ /g, '\u3000').replace(/([ˇˊˋ])\u3000/g, '$1').replace(/ /g, '\u3000')
     b = b - /^（.*）/ - /（.*）.*/
     audio-title = title - /，/g
-    audio-id = if i then audio-map["#audio-title.#b"] else audio-map["#audio-title.#b"] || audio-map[title]
+    audio-id = if i then audio-map["#audio-title.#b"] else audio-map["#audio-title.#b"] || (audio-map[title] if title.length > 1)
     heteronyms[i] <<< {"=": audio-id} if audio-id
   delete entry<[ English francais Deutsch ]>
   chunk = JSON.stringify(entry).replace(


### PR DESCRIPTION
原本的程式看起來是為了要讓在 dict-concised.audio.json 裡面注音錯誤的條目也可以對應到發音檔，如：一制性資源定位法

這個規則應該不適用單字的條目，易造成混淆。過濾掉後，會影響到的條目如下：

 仔
 佗
 侗
 俛
 倥
 儐
 吽
 呱
 咋
 咧
 咯
 哩
 喀
 喏
 嗆
 嗑
 嘬
 嘿
 噌
 噯
 噶
 圾
 埤
 場
 妃
 媛
 宓
 崗
 帑
 廁
 弛
 愒
 懵
 拶
 挾
 摻
 摽
 撬
 撮
 擰
 攘
 攣
 楔
 氓
 氬
 汆
 沆
 沈
 浣
 潦
 炔
 煠
 煬
 熟
 燎
 玩
 町
 畦
 瘩
 癌
 睪
 瞿
 示
 絜
 繇
 翮
 聘
 膜
 荑
 莆
 蕁
 蜿
 蠕
 衕
 褊
 襬
 覲
 訾
 豁
 豉
 踅
 踹
 迆
 遛
 邋
 酩
 鑿
 門
 閩
 闖
 頁
 頃
 頗
 餾
 骯
 鹽
