### PR TITLE
Update README for Ubuntu dependency installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ root@4a7bd751fd9e:/usr/local/src/moedict-webkit# make
 ## 需求
 
 * Node.js 0.10.x
+    * npm
 * Perl 5.8.0+
 * Python
     * lxml
@@ -23,10 +24,7 @@ root@4a7bd751fd9e:/usr/local/src/moedict-webkit# make
 
 ```sh
 sudo apt-get update
-sudo apt-get install -y python-software-properties python g++ make
-sudo add-apt-repository -y ppa:chris-lea/node.js
-sudo apt-get update
-sudo apt-get install nodejs python-lxml curl
+sudo apt-get install -y python g++ make nodejs python-lxml curl npm
 ```
 
 ## 安裝環境


### PR DESCRIPTION
As Ubuntu 12.04 is reaching EOL and nodejs v0.10 is builtin in Ubuntu 14.04 and Debian Wheezy, there is no need to use ppa to install nodejs anymore, also, npm should be added as dependency.